### PR TITLE
Fixed contrast being only 0 or 255

### DIFF
--- a/src/main/java/dburyak/pi/ssd1306/Display.java
+++ b/src/main/java/dburyak/pi/ssd1306/Display.java
@@ -684,7 +684,7 @@ public class Display {
             LOG.error("contrast factor is more than 1.0D, normalizing : contrastFactor = [%f]", contrastFactor);
             contrastNorm = 1.0D;
         }
-        return (int) contrastNorm * 255;
+        return (int) (contrastNorm * 255);
     }
 
     /**


### PR DESCRIPTION
I noticed that the `Display#contrast(double)` method did an int cast on the double before multiplying, which would result in values that were only 0 or 255.

```java
return (int) contrastNorm * 255;
```

I added parentheses around the multiplication expression so that the multiplied value from 0.0 to 255.0 would be cast to an int. 

```java
return (int) (contrastNorm * 255);
```

I have verified that this now works correctly on my [128x32 OLED display](https://www.adafruit.com/product/3527) with a simple dimming test (Kotlin):
```kotlin
display.apply {
    text("Text test", Display.Position.of(0, 0))
    sync()

    for (j in 1..5) {
        for (i in 100 downTo 0) {
            contrast(i / 100.0)
            text("$i%", Display.Position.of(0, 16))
            sync()
            sleep(Duration.ofMillis(5L))
        }
        for (i in 0..100) {
            contrast(i / 100.0)
            text("$i%", Display.Position.of(0, 16))
            sync()
            sleep(Duration.ofMillis(5L))
        }
        contrast(1.0)
    }
    text("100%", Display.Position.of(0, 16))
    sync()
}
```